### PR TITLE
Mention which stop to get off the Red Line

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@
           <p>
             <ul>
               <li><img src="./images/bus.png" /> Take the <span class="highlight">Silver Line SL1</span> Express Bus Service from Logan to <span class="highlight">South Station</span> (21 minutes)</li>
-              <li><img src="./images/subway.png" /> Transfer to the <span class="highlight">Red Line</span> Subway towards Alewife (7 minutes)</li>
+              <li><img src="./images/subway.png" /> Transfer to the <span class="highlight">Red Line</span> Subway towards Alewife and get off at <span class="highlight">Kendall/MIT</span> (7 minutes)</li>
               <li><img src="./images/walk.png" /> Walk to the Microsoft New England Research and Development Center (7 minutes)</li>
             </ul>
           </p>


### PR DESCRIPTION
We don't want attendees going all the way to Alewife,
so let them know they need to get off at Kendall.
