### PR TITLE
Create hubot_spec.json

### DIFF
--- a/hubot_spec.json
+++ b/hubot_spec.json
@@ -1,0 +1,18 @@
+{
+    "conference": {
+        "name": "Monitorama",
+        "location": {
+            "address1": "Gerding Theater at the Armory",
+            "address2": "128 NW 11th Ave",
+            "city": "Portland",
+            "state": "OR",
+            "zipcode": "97209"
+        },
+        "dates": {
+            "conf start": "06.15.2015",
+            "conf end": "06.17.2015",
+            "cfp start": "CLOSED",
+            "cfp end": ""
+        }
+    }
+}


### PR DESCRIPTION
BosOps has a slack channel with a hubot that calls the Meetup.com api and returns us a list of groups we care about and if requested the the details on the latest meetup for each of these groups.  This allows everyone to know when the latest meetup is scheduled and helps to avoid date conflicts.

I, along with a few others, have been toying with the idea of doing the same type of thing for conferences.  It would be great if we could just pass the bot a conference name and a url then ask it to give us any details found about that conference.  It would certainly make it easier then a lot of people trying to remember dates and such.  Why open a browser, remember a url, try and find the info you want, etc when you can just ask a hubot.  Many of us live in Slack now anyway.

To this end I have created an initial [spec](https://github.com/mattyjones/conf_json_spec/blob/master/spec.JSON) for this purpose and also written a [script](https://github.com/jeffbyrnes/bosops-hubot/blob/master/scripts/confrences.js) to tell the hubot how to deal with it.  This is just the beginning of what we hope to do with the bot and it would be great if Monitorama would be willing to add this file to their site so that we can add your conference into our list.

If you have any questions or concerns, feel free to let me know.