### PR TITLE
Show a modal with metadata about the speaker's talk

### DIFF
--- a/2019/baltimore.html
+++ b/2019/baltimore.html
@@ -320,6 +320,24 @@
       <p>&copy; Copyright 2019 Monitorama LLC</p>
     </div>
 
+    <!-- speaker modal -->
+    <div class="modal fade" tabindex="-1" role="dialog" id="speakerModal">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="speakerTitle"></h4>
+          </div>
+          <div class="modal-body">
+            <p id="speakerAbstract"></p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/flipclock/0.7.8/flipclock.min.js"></script>
     <script type="text/javascript" src="javascripts/bootstrap.min.js"></script>

--- a/2019/javascripts/main.js
+++ b/2019/javascripts/main.js
@@ -120,7 +120,24 @@ for (var i in speakers) {
 
   // populate titles for schedule
   if (speakers[i].title.length > 0) {
-    $('.schedule span.speaker:contains(' + speakers[i].name + ')').parent().find('h5').html(speakers[i].title);
+    $('.schedule span.speaker:contains(' + speakers[i].name + ')').parent().find('h5')
+        .html(speakers[i].title)
+        .css('cursor', 'pointer')
+        .attr('data-hash', speakers[i].hash)
+        .on('click', function (e) {
+          var hash = e.target.getAttribute('data-hash');
+          // When clicking on this title, show a modal with information about the speaker's talk
+          var results = $.grep(speakers, function(speaker) {
+            return speaker.hash === hash
+          });
+
+          if (results[0]) {
+            var speaker = results[0]
+            $("#speakerModal #speakerTitle").html(speaker.title);
+            $("#speakerModal #speakerAbstract").html(speaker.abstract);
+            $("#speakerModal").modal()
+          }
+    });
   }
 
   // populate abstracts for schedule

--- a/2019/javascripts/main.js
+++ b/2019/javascripts/main.js
@@ -121,22 +121,22 @@ for (var i in speakers) {
   // populate titles for schedule
   if (speakers[i].title.length > 0) {
     $('.schedule span.speaker:contains(' + speakers[i].name + ')').parent().find('h5')
-        .html(speakers[i].title)
-        .css('cursor', 'pointer')
-        .attr('data-hash', speakers[i].hash)
-        .on('click', function (e) {
-          var hash = e.target.getAttribute('data-hash');
-          // When clicking on this title, show a modal with information about the speaker's talk
-          var results = $.grep(speakers, function(speaker) {
-            return speaker.hash === hash
-          });
+      .html(speakers[i].title)
+      .css('cursor', 'pointer')
+      .attr('data-hash', speakers[i].hash)
+      .on('click', function (e) {
+        var hash = e.target.getAttribute('data-hash');
+        // When clicking on this title, show a modal with information about the speaker's talk
+        var results = $.grep(speakers, function(speaker) {
+          return speaker.hash === hash
+        });
 
-          if (results[0]) {
-            var speaker = results[0]
-            $("#speakerModal #speakerTitle").html(speaker.title);
-            $("#speakerModal #speakerAbstract").html(speaker.abstract);
-            $("#speakerModal").modal()
-          }
+        if (results[0]) {
+          var speaker = results[0]
+          $("#speakerModal #speakerTitle").html(speaker.title);
+          $("#speakerModal #speakerAbstract").html(speaker.abstract);
+          $("#speakerModal").modal()
+        }
     });
   }
 

--- a/2019/stylesheets/main.css
+++ b/2019/stylesheets/main.css
@@ -594,6 +594,15 @@ section.welcome {
 .schedule ul li span.speaker {
   font-size: 0.7em;
 }
+
+.modal-content {
+  border-radius: 0;
+}
+
+.modal-title, .modal-content {
+  font-family: "MotivaSans-Medium";
+}
+
 /* END SCHEDULE */
 
 /* START SPONSORS */


### PR DESCRIPTION
This PR adds some UX improvements for the schedule list shown for Monitorama Balitmore. Now, when you click on a talk's title, you'll see a modal with the talk's title and abstract.

## Examples

- Desktop
![Screen Shot 2019-09-23 at 10 05 33 AM](https://user-images.githubusercontent.com/312291/65433079-55053080-ddea-11e9-975b-6fe52b714e85.png)


- Mobile 
![Screen Shot 2019-09-23 at 10 06 51 AM](https://user-images.githubusercontent.com/312291/65437414-bf6d9f00-ddf1-11e9-8330-f903bd4e6d3a.png)

