### PR TITLE
Fix past events footer links for PDX 2020

### DIFF
--- a/2020/pdx.html
+++ b/2020/pdx.html
@@ -384,14 +384,14 @@
           <div class="col-md-2">
             <h5>Past US Events</h5>
             <ul>
-              <li><a href="2019/baltimore.html">Baltimore 2019</a></li>
-              <li><a href="2019/pdx.html">PDX 2019</a></li>
-              <li><a href="2018/pdx.html">PDX 2018</a></li>
-              <li><a href="2017/pdx.html">PDX 2017</a></li>
-              <li><a href="2016/pdx.html">PDX 2016</a></li>
-              <li><a href="2015/pdx.html">PDX 2015</a></li>
-              <li><a href="2014/pdx.html">PDX 2014</a></li>
-              <li><a href="2013/boston.html">Boston 2013</a></li>
+              <li><a href="/2019/baltimore.html">Baltimore 2019</a></li>
+              <li><a href="/2019/pdx.html">PDX 2019</a></li>
+              <li><a href="/2018/pdx.html">PDX 2018</a></li>
+              <li><a href="/2017/pdx.html">PDX 2017</a></li>
+              <li><a href="/2016/pdx.html">PDX 2016</a></li>
+              <li><a href="/2015/pdx.html">PDX 2015</a></li>
+              <li><a href="/2014/pdx.html">PDX 2014</a></li>
+              <li><a href="/2013/boston.html">Boston 2013</a></li>
             </ul>
           </div>
           <div class="col-md-2">


### PR DESCRIPTION
Footer links for Past US Events in PDX 2020 currently resolve like:
http://monitorama.com/2020/2019/baltimore.html

Updated the links to point from the base path to resolve like:
http://monitorama.com/2019/baltimore.html