### PR TITLE
Proposed COVID-19 vaccination policy for PDX 2021

### DIFF
--- a/2021/pdx.html
+++ b/2021/pdx.html
@@ -323,6 +323,12 @@
           </section>
 
           <section class="conduct">
+            <h4>COVID-19 Vaccination Policy</h4>
+
+            <p>To ensure the safety and well-being of everyone in attendance, we are asking all participants (including vendors, sponsors, speakers, staff and attendees) to have received a <strong>full COVID-19 vaccination at least two (2) weeks prior to travel</strong> for this event.</p>
+
+            <p>If you cannot comply with this requirement, we ask that you request a ticket refund by August 30, 2021 and enjoy the show by watching our live stream and participating remotely in our Slack workspace.</p>
+
             <h4>Code of Conduct</h4>
 
             <p>All delegates, speakers, sponsors and volunteers at any Monitorama event are required to agree with the following code of conduct. Organizers will enforce this code throughout the event.</p>


### PR DESCRIPTION
Putting this out there for review and discussion. The goal here is to set expectations for anyone participating in the event.

I will require this for our staff and vendors, but it's very unlikely that we could _effectively_ enforce this policy for everyone. Vaccination cards are non-standardized and easily forged.

Regardless, it's my expectation that folks _will_ abide by this policy, because this event attracts intelligent and conscientious individuals who understand the risks and are doing their part to combat this pandemic. 🥰 